### PR TITLE
use correct framework

### DIFF
--- a/BallisticCalculatorNet.Api/BallisticCalculatorNet.Api.csproj
+++ b/BallisticCalculatorNet.Api/BallisticCalculatorNet.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BallisticCalculatorNet.Common/BallisticCalculatorNet.Common.csproj
+++ b/BallisticCalculatorNet.Common/BallisticCalculatorNet.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet.InputPanels/BallisticCalculatorNet.InputPanels.csproj
+++ b/BallisticCalculatorNet.InputPanels/BallisticCalculatorNet.InputPanels.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet.MeasurementControl/BallisticCalculatorNet.MeasurementControl.csproj
+++ b/BallisticCalculatorNet.MeasurementControl/BallisticCalculatorNet.MeasurementControl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet.ReticleCanvas/BallisticCalculatorNet.ReticleCanvas.csproj
+++ b/BallisticCalculatorNet.ReticleCanvas/BallisticCalculatorNet.ReticleCanvas.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet.ReticleEditor/BallisticCalculatorNet.ReticleEditor.csproj
+++ b/BallisticCalculatorNet.ReticleEditor/BallisticCalculatorNet.ReticleEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet.UnitTest/BallisticCalculatorNet.UnitTest.csproj
+++ b/BallisticCalculatorNet.UnitTest/BallisticCalculatorNet.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/BallisticCalculatorNet/BallisticCalculatorNet.csproj
+++ b/BallisticCalculatorNet/BallisticCalculatorNet.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
   <OutputType>WinExe</OutputType>
-  <TargetFramework>net80-windows</TargetFramework>
+  <TargetFramework>net8.0-windows</TargetFramework>
   <UseWindowsForms>true</UseWindowsForms>
   <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/Extensions/BallisticCalculatorExtension.SaveToPdf/BallisticCalculatorExtension.SaveToPdf.csproj
+++ b/Extensions/BallisticCalculatorExtension.SaveToPdf/BallisticCalculatorExtension.SaveToPdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/Gehtsoft.Winforms.FluentAssertions.Test/Gehtsoft.Winforms.FluentAssertions.Test.csproj
+++ b/Gehtsoft.Winforms.FluentAssertions.Test/Gehtsoft.Winforms.FluentAssertions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/Gehtsoft.Winforms.FluentAssertions/Gehtsoft.Winforms.FluentAssertions.csproj
+++ b/Gehtsoft.Winforms.FluentAssertions/Gehtsoft.Winforms.FluentAssertions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)